### PR TITLE
use openjdk:8-jdk-slim as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8
+FROM openjdk:8-jdk-slim
 MAINTAINER info@hortonworks.com
 
 ENV VERSION 2.5.0-dev.1
@@ -6,7 +6,7 @@ ENV VERSION 2.5.0-dev.1
 WORKDIR /
 
 # Install zip
-RUN apt-get update --no-install-recommends && apt-get install -y zip=3.0-8 && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update --no-install-recommends && apt-get install -y zip procps && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install the cloudbreak app
 ADD https://cloudbreak-maven.s3.amazonaws.com/releases/com/sequenceiq/cloudbreak/$VERSION/cloudbreak-$VERSION.jar /cloudbreak.jar


### PR DESCRIPTION
Modify Dockerfile to use openjdk:8-jdk-slim as base image because java images had been deprecated and didn't updated since 2016-12-31.

@keyki Please merge after the release of the Cloudbreak's 2.4.0 version.