### PR TITLE
BUG-111336 - added pipeline script for tagging. not used on jenkins yet.

### DIFF
--- a/.jenkins/dev-pipeline/dockerhub-tag.groovy
+++ b/.jenkins/dev-pipeline/dockerhub-tag.groovy
@@ -1,0 +1,20 @@
+pipeline {
+    agent any
+
+    stages {
+        stage('Tag Cloudbreak') {
+            environment {
+                DOCKERHUB_USERNAME = credentials('dockerhub-username')
+                DOCKERHUB_PASSWORD = credentials('dockerhub-password')
+            }
+            steps {
+                script {
+                    currentBuild.displayName = "${BUILD_NUMBER}-${VERSION}"
+                }
+                sh '''
+                    make dockerhub
+                '''
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pipeline job is created:
http://ci-cloudbreak.eng.hortonworks.com/view/cloudbreak/job/cloudbreak-dockerhub-tag-pipeline/

But not wired into anything yet.