### PR TITLE
Update REPO url to use HWX standard repo url 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM openjdk:10-jdk-slim
+FROM hortonworks/hwx_openjdk:10-jdk-slim
 MAINTAINER info@hortonworks.com
 
-ENV VERSION 2.9.0-dev.128
+# REPO URL to download jar
+ARG REPO_URL=https://repo.hortonworks.com/content/repositories/releases
+ARG VERSION=''
+
+ENV VERSION ${VERSION}
 
 WORKDIR /
 
@@ -9,7 +13,7 @@ WORKDIR /
 RUN apt-get update --no-install-recommends && apt-get install -y zip procps && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install the cloudbreak app
-ADD https://cloudbreak-maven.s3.amazonaws.com/releases/com/sequenceiq/cloudbreak/$VERSION/cloudbreak-$VERSION.jar /cloudbreak.jar
+ADD ${REPO_URL}/com/sequenceiq/cloudbreak/$VERSION/cloudbreak-$VERSION.jar /cloudbreak.jar
 
 # add jmx exporter
 ADD jmx_prometheus_javaagent-0.10.jar /jmx_prometheus_javaagent.jar

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 export MAVEN_METADATA_URL = maven.sequenceiq.com/releases/com/sequenceiq/cloudbreak/maven-metadata.xml
-export DOCKER_IMAGE = hortonworks/cloudbreak
 
 dockerhub:
 	./deploy.sh $(VERSION)


### PR DESCRIPTION
Updating base image to use HWX base image
Instead of dockerhub-tag creating the images, using docker command to create images, this gives us the flexibility to create dev and rc releases image independently, also we use different repo url in dev and production environment.